### PR TITLE
remove setup-docker-action, update example build/release yml files

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,27 +32,11 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
-    - name: Set up Docker
-      uses: docker/setup-docker-action@v4
-      with:
-        daemon-config: |
-          {
-            "debug": true,
-            "features": {
-              "containerd-snapshotter": false
-            }
-          }
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
         install: true               # Makes `docker buildx` the default subcommand
         driver: docker-container    # Use host daemon so images are visible to docker inspect
-
-    # Ensure we are on the default Docker context so start-cli can inspect images
-    # - name: Ensure default Docker context
-    #   run: docker context use default
-    #   shell: bash
 
     - name: Install start-cli
       run: |

--- a/buildService.yml
+++ b/buildService.yml
@@ -17,14 +17,22 @@ jobs:
         uses: start9labs/sdk@v2
 
       - name: Checkout services repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Build the service package
         id: build
+        env:
+          S9DEVKEY: ${{ secrets.S9DEVKEY }}
         run: |
-          start-cli init
+          start-cli init-key
+          if [[ -n "$S9DEVKEY" ]]; then
+            echo "Using developer key from secrets to sign the package."
+            printf '%s' "$S9DEVKEY" > ~/.startos/developer.key.pem
+          else
+            echo "Using newly generated developer key to sign the package."
+          fi
           RUST_LOG=debug RUST_BACKTRACE=1 make
           PACKAGE_ID=$(start-cli s9pk inspect *.s9pk manifest | jq -r '.id')
           echo "package_id=${PACKAGE_ID}" >> $GITHUB_ENV
@@ -32,7 +40,7 @@ jobs:
         shell: bash
 
       - name: Upload .s9pk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ env.package_id }}.s9pk
           path: ./${{ env.package_id }}.s9pk

--- a/releaseService.yml
+++ b/releaseService.yml
@@ -15,7 +15,7 @@ jobs:
         uses: start9labs/sdk@v2
 
       - name: Checkout services repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -24,7 +24,7 @@ jobs:
         env:
           S9DEVKEY: ${{ secrets.S9DEVKEY }}
         run: |
-          start-cli init
+          start-cli init-key
           if [[ -n "$S9DEVKEY" ]]; then
             echo "Using developer key from secrets to sign the package."
             printf '%s' "$S9DEVKEY" > ~/.startos/developer.key.pem


### PR DESCRIPTION
- removed 'setup-docker-action' (was not needed and causes weird context conflicts)
- updated example files: new action versions
- updated example files: start-cli init -> init-key
- updated example files: use S9DEVKEY (if defined) also for normal builds